### PR TITLE
Implement support for additional user volumes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,24 @@ resource "docker_container" "this" {
     }
   }
 
+  # user-defined additional downloads volumes
+  dynamic "volumes" {
+    for_each = local.processed_user_volumes
+    iterator = volume
+    content {
+      volume_name    = volume.value.volume_name
+      container_path = "/downloads/${volume.value.dir_name}"
+    }
+  }
+
   must_run = true
   restart  = var.restart
   start    = var.start
+}
+
+locals {
+  processed_user_volumes = [for user_volume in var.user_volumes : {
+    volume_name = user_volume.volume_name
+    dir_name    = user_volume.dir_name != "" ? user_volume.dir_name : user_volume.volume_name
+  }]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,3 +70,16 @@ variable "restart" {
   DESCRIPTION
   default     = "unless-stopped"
 }
+
+variable "user_volumes" {
+  type        = list(object({
+    volume_name = string
+    dir_name    = string
+  }))
+  description = <<-DESCRIPTION
+  A list of additional user volumes to attach inside the downloads directory of the container. Each
+  volume will be attached to `/downloads/{dir_name}` if `dir_name` is not empty, or
+  `/downloads/volume_name` otherwise.
+  DESCRIPTION
+  default     = []
+}


### PR DESCRIPTION
These additional user volumes will be attached inside the `/downloads`
directory.

Fixes #2.